### PR TITLE
ci: fix match authentication by generating basic auth at runtime

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -20,6 +20,13 @@ jobs:
       - name: CocoaPods install
         run: bundle exec pod install --deployment
 
+      # ✅ 여기서 Basic auth 헤더를 런타임에 생성 (개행/숨은문자 이슈 제거)
+      - name: Build match basic auth header
+        run: |
+          set -euo pipefail
+          AUTH_B64="$(printf "x-access-token:%s" "${{ secrets.MATCH_PAT }}" | base64 | tr -d '\r\n')"
+          echo "MATCH_GIT_BASIC_AUTHORIZATION=$AUTH_B64" >> "$GITHUB_ENV"
+
       - name: Build & Upload TestFlight
         env:
           CI: "true"
@@ -30,6 +37,5 @@ jobs:
 
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ env.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: bundle exec fastlane ios beta


### PR DESCRIPTION
# 🔐 Fix match authentication in CI (GitHub Actions)

## 🔥 Changes Made

### CI 환경에서 fastlane match 인증 안정화
- GitHub Actions에서 `match` 인증서 저장소 clone 시 발생하던 오류 해결
  - `fatal: unable to access ... (400)` 문제 원인 분석 및 대응
- GitHub PAT을 Secret으로 직접 base64 저장하지 않고,
  **CI 런타임에서 Authorization 헤더를 생성하도록 변경**
  - 개행/숨은 문자로 인한 Basic Auth 헤더 깨짐 이슈 방지
- `git_basic_authorization` 값은 `$GITHUB_ENV`를 통해 주입

### fastlane / GitHub Actions 역할 분리
- GitHub Secrets에는 **PAT 원문(`MATCH_PAT`)만 저장**
- Authorization 헤더(`MATCH_GIT_BASIC_AUTHORIZATION`)는
  GitHub Actions에서 동적으로 생성
- Fastfile은 CI에서 전달된 헤더를 그대로 사용하도록 구성

---

## 🧪 How to Test

### CI 기준 검증
1. main 브랜치에 merge
2. `iOS TestFlight` GitHub Actions 워크플로우 실행
3. `match(type: appstore)` 단계에서 certificates repo clone 성공 확인
4. 이후 Archive / Export / TestFlight 업로드 정상 진행 여부 확인

---

## 🔐 Required GitHub Secrets

- `ASC_KEY_ID`
- `ASC_ISSUER_ID`
- `ASC_KEY_P8`
- `MATCH_GIT_URL`
- `MATCH_PASSWORD`
- `MATCH_PAT` (GitHub Personal Access Token, raw value)

---

## 🛠 Notes

- CI 환경에서는 interactive git 인증이 불가능하므로
  HTTPS + PAT 기반 인증을 사용합니다.
- Authorization 헤더를 런타임에서 생성함으로써
  base64 개행/마스킹 이슈로 인한 clone 실패를 방지했습니다.
- 로컬 개발 환경에는 영향을 주지 않습니다.
