### PR TITLE
ci(fastlane): reinitialize match signing and fix app identifier for CI builds

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,4 +1,4 @@
-# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
+app_identifier("com.seongyeon.bibleatlas.release") 
 # apple_id("[[APPLE_ID]]") # Your Apple Developer Portal username
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,6 +51,7 @@ platform :ios do
 
     match(
       type: "appstore",
+      app_identifier: "com.seongyeon.bibleatlas.release",
       readonly: ENV["CI"] == "true",
       git_url: ENV["MATCH_GIT_URL"],
       git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"]


### PR DESCRIPTION
## 🔥 What’s Changed

이번 PR에서는 iOS CI/CD 파이프라인에서 발생하던 코드사인(Signing) 문제를 근본적으로 해결했습니다.

### 1. Fastlane match 재초기화
- 기존 match repo 비밀번호 유실로 인한 복호화 실패 문제 해결
- match repo 새로 생성 및 암호 재설정
- Apple Distribution 인증서 / App Store 프로비저닝 프로파일 재발급
- CI 환경에서 사용 가능하도록 `readonly` 옵션 적용

### 2. App Identifier 명시
- `com.seongyeon.bibleatlas.release` 를 명확히 지정
- match가 올바른 앱 대상에 대해 인증서/프로파일을 생성하도록 수정
- `fastlane/Appfile` 및 Fastfile 설정 보완

### 3. CI 환경 match 인증 안정화
- GitHub Actions에서 match repo 접근 가능하도록 설정
- CI Secrets 정리
  - `MATCH_PASSWORD`
  - `MATCH_GIT_URL`
  - `MATCH_GIT_BASIC_AUTHORIZATION`
- 로컬 / CI 환경 모두 동일한 코드사인 흐름 보장

---

## 🧪 How to Test

### 로컬
```bash
bundle exec fastlane ios beta
